### PR TITLE
feat: add lastName field to user schema

### DIFF
--- a/app/pages/users/index.vue
+++ b/app/pages/users/index.vue
@@ -5,6 +5,7 @@ import { RouterLink } from 'vue-router'
 interface User {
   id: string
   name: string
+  lastName: string | null
   email: string
   createdAt: string
 }
@@ -47,6 +48,7 @@ onMounted(load)
           <tr>
             <th>ID</th>
             <th>Name</th>
+            <th>Last name</th>
             <th>Email</th>
             <th>Created</th>
           </tr>
@@ -55,6 +57,7 @@ onMounted(load)
           <tr v-for="user in users" :key="user.id">
             <td>{{ user.id }}</td>
             <td>{{ user.name }}</td>
+            <td>{{ user.lastName ?? '—' }}</td>
             <td>{{ user.email }}</td>
             <td>{{ new Date(user.createdAt).toLocaleString() }}</td>
           </tr>

--- a/app/pages/users/new.vue
+++ b/app/pages/users/new.vue
@@ -5,6 +5,7 @@ import { useRouter } from 'vue-router'
 const router = useRouter()
 
 const name = ref('')
+const lastName = ref('')
 const email = ref('')
 const pending = ref(false)
 const error = ref<string | null>(null)
@@ -16,7 +17,7 @@ async function submit() {
     const res = await fetch('/api/users', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ name: name.value, email: email.value }),
+      body: JSON.stringify({ name: name.value, lastName: lastName.value, email: email.value }),
     })
     if (!res.ok) {
       const body = await res.json().catch(() => null)
@@ -39,6 +40,11 @@ async function submit() {
       <label>
         <span>Name</span>
         <input v-model="name" type="text" required autocomplete="name" />
+      </label>
+
+      <label>
+        <span>Last name</span>
+        <input v-model="lastName" type="text" autocomplete="family-name" />
       </label>
 
       <label>

--- a/server/api/users.post.ts
+++ b/server/api/users.post.ts
@@ -4,7 +4,7 @@ import { useDrizzle, tables } from '../utils/drizzle'
 
 // POST /api/users { name, email } -> create user
 export default defineHandler(async (event) => {
-  const body = await readBody<{ name?: string; email?: string }>(event)
+  const body = await readBody<{ name?: string; lastName?: string; email?: string }>(event)
   if (!body?.name || !body?.email) {
     throw new HTTPError('name and email are required', { status: 400 })
   }
@@ -12,7 +12,7 @@ export default defineHandler(async (event) => {
   const db = await useDrizzle()
   const [user] = await db
     .insert(tables.users)
-    .values({ name: body.name, email: body.email })
+    .values({ name: body.name, lastName: body.lastName || null, email: body.email })
     .returning()
   return user
 })

--- a/server/database/migrations/0002_charming_iron_monger.sql
+++ b/server/database/migrations/0002_charming_iron_monger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "last_name" text;

--- a/server/database/migrations/meta/0002_snapshot.json
+++ b/server/database/migrations/meta/0002_snapshot.json
@@ -1,0 +1,72 @@
+{
+  "id": "15d32382-64d2-4f39-a678-40e1dcfabcad",
+  "prevId": "36c196e1-60e2-4580-b5a0-c41c80590409",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1780922879396,
       "tag": "0001_amazing_annihilus",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1780927800441,
+      "tag": "0002_charming_iron_monger",
+      "breakpoints": true
     }
   ]
 }

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -4,6 +4,7 @@ import { createdAt } from './utils'
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
   name: text('name').notNull(),
+  lastName: text('last_name'),
   email: text('email').notNull().unique(),
   createdAt,
 })


### PR DESCRIPTION
This is just a test of the automated previews with migrations

---

## Summary
- Add nullable `last_name` column to the `users` table
- Generate Drizzle migration `0002_charming_iron_monger.sql`

## Migration
```sql
ALTER TABLE "users" ADD COLUMN "last_name" text;
```

The field is nullable so existing rows remain valid without a backfill.

## Test plan
- [ ] `pnpm run db:migrate` applies cleanly