### PR TITLE
fix: keep dev server resilient when a local migration fails

### DIFF
--- a/server/database/dev-migration-plugin.ts
+++ b/server/database/dev-migration-plugin.ts
@@ -21,11 +21,23 @@ export default definePlugin(() => {
   // migrator does not apply there, so skip and let `pnpm db:migrate` handle it.
   if (process.env.DATABASE_URL) return
 
+  // Apply migrations as a detached, fully-isolated task: a failing migration must not
+  // take down the dev server. Drizzle runs the whole pending set in ONE transaction, so
+  // a single bad statement rolls them all back — on a fresh `.data/pg` that leaves an
+  // empty DB. We keep the server up and print a short, actionable warning instead of a
+  // raw WASM stack trace, so the dev can fix the migration (or reset `.data/pg`) and the
+  // plugin re-runs on the next reload.
   void (async () => {
     const db = await useDrizzle()
     const migrationsFolder = resolve(process.cwd(), 'server/database/migrations')
     await migrate(db as never, { migrationsFolder })
-  })().catch((error) => {
-    console.error('[db] failed to apply migrations', error)
+  })().catch((error: unknown) => {
+    const reason = error instanceof Error ? error.message : String(error)
+    console.warn(
+      `\n⚠️  [db] Migration failed — dev server is still running, but the local schema may be incomplete.\n` +
+        `    Reason: ${reason}\n` +
+        `    Fix the offending migration (DB requests will 500 until then), then save to reapply.\n` +
+        `    To start clean, stop the server, delete \`.data/pg\`, and restart.\n`,
+    )
   })
 })


### PR DESCRIPTION
## Problem

A failing local migration left the dev experience broken. Drizzle runs the entire pending migration set in a single transaction (`pg-core` dialect `migrate`), so one bad statement rolls back **all** migrations. On a fresh `.data/pg` that leaves an empty schema and every DB request 500s with `relation "users" does not exist`. The previous `.catch` only `console.error`'d a multi-screen WASM stack trace with no guidance.

## Fix

`server/database/dev-migration-plugin.ts`:

- Migration still runs as a detached task so no failure (sync or async) can take down the dev server.
- On failure, print a short, actionable warning (reason = `error.message`, server-still-up note, how DB requests behave, and the `delete .data/pg` reset path) instead of a raw stack dump.
- Save-to-reapply still works via plugin reload.

## Verification

- Broken migration → server boots, `/` returns 200, clean ⚠️ warning, no crash.
- Happy path (valid migrations, fresh DB) → migrations apply, `/api/users` returns 200, no warning.